### PR TITLE
bugfix/user-button-on-adc

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Used pins:
 | DHT-11/22 | pull-up resistor 4k7 to VCC | D4 | GPIO4 |
 | HX711 Dout | | A0 | GPIO2 |
 | HX711 Sck | | A1 | GPIO3 |
-| Push-Button | to GND (active low) | D3 | GPIO7 |
+| Push-Button | to GND (active low) | D3 | GPIO7 (& battery test control) |
 | LED | to VCC (active low) | A2 | GPIO1 |
        
 ## Transmitted LoRa message (binary encoded)

--- a/arduino_beehive_sensor_lora/SensorReader.h
+++ b/arduino_beehive_sensor_lora/SensorReader.h
@@ -117,6 +117,7 @@ class SensorReader {
     }
 
     long readVcc() {
+      noInterrupts();
       #if defined(__ASR6501__)
         pinMode(ADC_CTL, OUTPUT);
         digitalWrite(ADC_CTL, LOW);
@@ -135,6 +136,7 @@ class SensorReader {
         result = 1126400L / result; // Back-calculate AVcc in mV
         return result;
       #endif
+      interrupts();
     }
 
 };

--- a/arduino_beehive_sensor_lora/arduino_beehive_sensor_lora.ino
+++ b/arduino_beehive_sensor_lora/arduino_beehive_sensor_lora.ino
@@ -57,7 +57,7 @@ typedef union {
 unsigned long getTime();
 void onSwitchManualMode();
 
-#define RAW_MEASURE_INTERVAL    (4*SEC)   // Dragino only allows 8s, 4s, 2s, 1s
+#define RAW_MEASURE_INTERVAL    (8*SEC)   // Dragino only allows 8s, 4s, 2s, 1s
 #define MEASURE_INTERVAL        (5*MIN)
 #define UNCONDITIONAL_INTERVAL  (30*MIN)
 #define CONFIRMATION            false


### PR DESCRIPTION
fixed: battery measure reuses GPIO7 as ADC_CTL and caused a user button event